### PR TITLE
list: show version & don't show container ID's

### DIFF
--- a/list/containers.go
+++ b/list/containers.go
@@ -20,8 +20,8 @@ import (
 
 const (
 	// `eris ls` format.
-	standardTmplHeader = "{{toupper .}}\tON\tCONTAINER ID\tDATA CONTAINER"
-	standardTmpl       = "{{.ShortName}}\t{{asterisk .Info.State.Running}}\t{{short .Info.ID}}\t{{short (dependent .ShortName)}}"
+	standardTmplHeader = "{{toupper .}}\tON\tVERSION"
+	standardTmpl       = "{{.ShortName}}\t{{asterisk .Info.State.Running}}\t{{img .Info.Config.Image}}"
 
 	// `eris ls -a` format.
 	extendedTmplHeader = "{{toupper .}}\tON\tCONTAINER ID\tDATA CONTAINER\tIMAGE\tCOMMAND\tPORTS"
@@ -71,6 +71,16 @@ var (
 		// Pretty-format Docker ports.
 		"ports": func(container *docker.Container) string {
 			return util.FormulatePortsOutput(container)
+		},
+		"img": func(image string) string {
+			tag := strings.Split(image, ":")
+			if len(tag) == 2 {
+				return tag[1]
+			} else if len(tag) == 1 {
+				return "latest"
+			} else {
+				return "unknown"
+			}
 		},
 	}
 )


### PR DESCRIPTION
- closes #1126 
- `eris ls | eris chains ls | eris services ls` has changed from:
```
SERVICE      ON     CONTAINER ID     DATA CONTAINER
ipfs         -      8fbf248ec5       152097b1c7
keys         *      1fa7bfde8a       af611ab4c9
                                                       
CHAIN        ON     CONTAINER ID     DATA CONTAINER
meachain     *      dc796d986f       1a611eb0a4
```
to
```
SERVICE      ON     VERSION
ipfs         -      latest
keys         *      0.16.0
                                            
CHAIN        ON     VERSION
meachain     *      0.16.0
```
in order to show more relevant information