### PR TITLE
core: remove images from config & eris.toml

### DIFF
--- a/chains/make.go
+++ b/chains/make.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 
 	"github.com/eris-ltd/eris/chains/maker"
-	"github.com/eris-ltd/eris/config"
 	"github.com/eris-ltd/eris/definitions"
 	"github.com/eris-ltd/eris/keys"
 	"github.com/eris-ltd/eris/log"
+	"github.com/eris-ltd/eris/version"
 
 	"github.com/eris-ltd/eris-db/genesis"
 )
@@ -59,7 +59,7 @@ func MakeChain(do *definitions.Do) error {
 	// set infos
 	// do.Name; already set
 	// do.Accounts ...?
-	do.ChainImageName = path.Join(config.Global.DefaultRegistry, config.Global.ImageDB)
+	do.ChainImageName = path.Join(version.DefaultRegistry, version.ImageDB)
 	do.ExportedPorts = []string{"1337", "46656", "46657"}
 	do.UseDataContainer = true
 	do.ContainerEntrypoint = ""

--- a/config/config.go
+++ b/config/config.go
@@ -39,16 +39,6 @@ type Settings struct {
 	CrashReport       string `json:"CrashReport,omitempty" yaml:"CrashReport,omitempty" toml:"CrashReport,omitempty"`
 	ImagesPullTimeout string `json:"ImagesPullTimeout,omitempty" yaml:"ImagesPullTimeout,omitempty" toml:"ImagesPullTimeout,omitempty"`
 	Verbose           bool
-
-	// Image defaults.
-	DefaultRegistry string `json:"DefaultRegistry,omitempty" yaml:"DefaultRegistry,omitempty" toml:"DefaultRegistry,omitempty"`
-	BackupRegistry  string `json:"BackupRegistry,omitempty" yaml:"BackupRegistry,omitempty" toml:"BackupRegistry,omitempty"`
-
-	ImageData      string `json:"ImageData,omitempty" yaml:"ImageData,omitempty" toml:"ImageData,omitempty"`
-	ImageKeys      string `json:"ImageKeys,omitempty" yaml:"ImageKeys,omitempty" toml:"ImageKeys,omitempty"`
-	ImageDB        string `json:"ImageDB,omitempty" yaml:"ImageDB,omitempty" toml:"ImageDB,omitempty"`
-	ImageIPFS      string `json:"ImageIPFS,omitempty" yaml:"ImageIPFS,omitempty" toml:"ImageIPFS,omitempty"`
-	ImageCompilers string `json:"ImageCompilers,omitempty" yaml:"ImageCompilers,omitempty" toml:"ImageCompilers,omitempty"`
 }
 
 // New initializes the global configuration with default settings
@@ -130,15 +120,6 @@ func SetDefaults() (*viper.Viper, error) {
 	// Compiler defaults.
 	config.SetDefault("CompilersHost", "https://compilers.monax.io")
 	config.SetDefault("CompilersPort", "1"+strings.Replace(strings.Split(version.VERSION, "-")[0], ".", "", -1))
-
-	// Image defaults.
-	config.SetDefault("DefaultRegistry", version.DefaultRegistry)
-	config.SetDefault("BackupRegistry", version.BackupRegistry)
-	config.SetDefault("ImageData", version.ImageData)
-	config.SetDefault("ImageKeys", version.ImageKeys)
-	config.SetDefault("ImageDB", version.ImageDB)
-	config.SetDefault("ImageIPFS", version.ImageIPFS)
-	config.SetDefault("ImageCompilers", version.ImageCompilers)
 
 	return config, nil
 }

--- a/loaders/chains.go
+++ b/loaders/chains.go
@@ -110,7 +110,7 @@ func ChainsAsAService(chainName string) (*definitions.ServiceDefinition, error) 
 	}
 
 	chain.Service.Name = chain.Name
-	chain.Service.Image = path.Join(config.Global.DefaultRegistry, config.Global.ImageDB)
+	chain.Service.Image = path.Join(version.DefaultRegistry, version.ImageDB)
 	chain.Service.AutoData = true
 
 	s := &definitions.ServiceDefinition{

--- a/perform/perform.go
+++ b/perform/perform.go
@@ -19,6 +19,7 @@ import (
 	"github.com/eris-ltd/eris/definitions"
 	"github.com/eris-ltd/eris/log"
 	"github.com/eris-ltd/eris/util"
+	"github.com/eris-ltd/eris/version"
 
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/term"
@@ -1066,7 +1067,7 @@ func configureVolumesFromContainer(ops *definitions.Operation, service *definiti
 	opts := docker.CreateContainerOptions{
 		Name: util.UniqueName("interactive"),
 		Config: &docker.Config{
-			Image:           path.Join(config.Global.DefaultRegistry, config.Global.ImageData),
+			Image:           path.Join(version.DefaultRegistry, version.ImageData),
 			User:            "root",
 			WorkingDir:      config.ErisContainerRoot,
 			AttachStdout:    true,
@@ -1112,7 +1113,7 @@ func configureDataContainer(srv *definitions.Service, ops *definitions.Operation
 	//   that base image will not be present. in such cases use
 	//   the base eris data container.
 	if srv.Image == "" {
-		srv.Image = path.Join(config.Global.DefaultRegistry, config.Global.ImageData)
+		srv.Image = path.Join(version.DefaultRegistry, version.ImageData)
 	}
 
 	// Manipulate labels locally.

--- a/util/containers.go
+++ b/util/containers.go
@@ -374,7 +374,7 @@ func PullImage(image string, writer io.Writer) error {
 	r, w := io.Pipe()
 	opts := docker.PullImageOptions{
 		Repository:    image,
-		Registry:      config.Global.DefaultRegistry,
+		Registry:      version.DefaultRegistry,
 		Tag:           tag,
 		OutputStream:  w,
 		RawJSONStream: true,


### PR DESCRIPTION
- closes #908 and includes all images that were part of the `config` object. This was part of the design used by the previous cm/pm paradigm & leaves image versioning to the `image` field of the chain `config.toml` and service definition files (e.g. `~/.eris/services/keys.toml`) respectively. 
- removes confusion / bad UX from image versions & cli's assumptions