### PR TITLE
restructure so that we run through ALL of the tests

### DIFF
--- a/perform/perform_test.go
+++ b/perform/perform_test.go
@@ -1696,9 +1696,6 @@ func TestLogsSimple(t *testing.T) {
 		t.Fatalf("expected logs pulled, got %v", err)
 	}
 
-	fmt.Printf("MARMOT: %s\n", buf.String())
-	fmt.Printf("MARMOT BAD: %s\n", bufErr.String())
-
 	if !strings.Contains(bufErr.String(), "Starting eris-keys") {
 		t.Fatalf("expected certain log entries, got %q", bufErr.String())
 	}

--- a/perform/perform_test.go
+++ b/perform/perform_test.go
@@ -1696,8 +1696,8 @@ func TestLogsSimple(t *testing.T) {
 		t.Fatalf("expected logs pulled, got %v", err)
 	}
 
-	fmt.Printf("MARMOT: %s", buf.String())
-	fmt.Printf("MARMOT BAD: %s", bufErr.String())
+	fmt.Printf("MARMOT: %s\n", buf.String())
+	fmt.Printf("MARMOT BAD: %s\n", bufErr.String())
 
 	if !strings.Contains(bufErr.String(), "Starting eris-keys") {
 		t.Fatalf("expected certain log entries, got %q", bufErr.String())


### PR DESCRIPTION
Includes a sleeper function added to keep travis from stalling out, a placement of integration tests first in appveyor and travis runnings (so we can see if they actually run) followed by the unit testing. Also includes a minor formatting fixup for perform tests. 