### PR TITLE
Issue1230 introduce make test for gotests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ eris
 _obj
 _test
 
+# build target
+target
+
 # Architecture specific extensions/prefixes
 *.[568vq]
 [568vq].out

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,8 @@ build_eris:
 # test eris
 .PHONY: test
 test: build
-	@go test ${PACKAGES_NOVENDOR}
+	# run go tests sequentially for the different packages
+	@go test ${PACKAGES_NOVENDOR} -p 1
 
 ### Clean up
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,77 @@
+# ----------------------------------------------------------
+# REQUIREMENTS
+
+# - go installed locally
+# - for build_docker: docker installed locally
+
+# ----------------------------------------------------------
+
+SHELL := /bin/bash
+REPO := $(shell pwd)
+GOFILES_NOVENDOR := $(shell find ${REPO} -type f -name '*.go' -not -path "${REPO}/vendor/*")
+PACKAGES_NOVENDOR := $(shell go list github.com/eris-ltd/eris/... | grep -v /vendor/)
+VERSION := $(shell cat ${REPO}/version/version.go | tail -n 1 | cut -d \  -f 4 | tr -d '"')
+VERSION_MIN := $(shell echo ${VERSION} | cut -d . -f 1-2)
+COMMIT_SHA := $(shell echo `git rev-parse --short --verify HEAD`)
+
+DOCKER_NAMESPACE := quay.io/eris
+
+
+.PHONY: greet
+greet:
+	@echo "Hi! I'm the marmot that will help you with eris v${VERSION}"
+
+### Formatting, linting and vetting
+
+# check the code for style standards; currently enforces go formatting.
+# display output first, then check for success	
+.PHONY: check
+check:
+	@echo "Checking code for formatting style compliance."
+	@gofmt -l -d ${GOFILES_NOVENDOR}
+	@gofmt -l ${GOFILES_NOVENDOR} | read && echo && echo "Your marmot has found a problem with the formatting style of the code." 1>&2 && exit 1 || true
+
+# fmt runs gofmt -w on the code, modifying any files that do not match
+# the style guide.
+.PHONY: fmt
+fmt:
+	@echo "Correcting any formatting style corrections."
+	@gofmt -l -w ${GOFILES_NOVENDOR}
+
+### Dependency management for github.com/eris-ltd/eris
+
+# erase vendor wipes the full vendor directory
+.PHONY: erase_vendor
+erase_vendor:
+	rm -rf ${REPO}/vendor/
+
+# install vendor uses glide to install vendored dependencies
+.PHONY: install_vendor
+install_vendor:
+	go get github.com/Masterminds/glide
+	glide install
+
+### Building github.com/eris-ltd/eris
+
+# build all targets in github.com/eris-ltd/eris
+.PHONY: build
+build:	check build_eris
+
+# build eris
+.PHONY: build_eris
+build_eris:
+	go build -o ${REPO}/target/eris-${COMMIT_SHA} ./cmd/eris
+
+### Testing github.com/eris-ltd/eris
+
+# test eris
+.PHONY: test
+test: build
+	@go test ${PACKAGES_NOVENDOR}
+
+### Clean up
+
+# clean removes the target folder containing build artefacts
+.PHONY: clean
+clean:
+	-rm -r ./target

--- a/chains/maker/accounts.go
+++ b/chains/maker/accounts.go
@@ -112,7 +112,7 @@ func newErisDBAccountConstructor(accountName string, keyAddressType string,
 		// NOTE: [ben] these auxiliary fields in the constructor are to be deprecated
 		// but introduced to support current unsafe behaviour where all private keys
 		// are extracted from eris-keys
-		accountConstructor.untypedPublicKeyBytes = make([]byte, len(publicKeyBytes)) 
+		accountConstructor.untypedPublicKeyBytes = make([]byte, len(publicKeyBytes))
 		copy(accountConstructor.untypedPublicKeyBytes[:], publicKeyBytes[:])
 		// tendermint/go-crypto typebyte for ed25519
 		accountConstructor.typeBytePublicKey = byte(0x01)
@@ -122,7 +122,7 @@ func newErisDBAccountConstructor(accountName string, keyAddressType string,
 			// before we deprecate private_validator files
 			if privateKeyString, ok := genesisPrivateValidator.PrivKey[1].(string); ok {
 				if privateKeyBytes, err := hex.DecodeString(privateKeyString); err != nil {
-					return  nil, err
+					return nil, err
 				} else {
 					accountConstructor.untypedPrivateKeyBytes = make([]byte, len(privateKeyBytes))
 					copy(accountConstructor.untypedPrivateKeyBytes[:], privateKeyBytes[:])
@@ -167,7 +167,7 @@ func newErisDBAccountConstructor(accountName string, keyAddressType string,
 
 		if genesisPrivateValidator != nil && !blockPrivateValidator {
 			// explicitly copy genesis private validator for clarity
-			accountConstructor.genesisPrivateValidator = genesisPrivateValidator			
+			accountConstructor.genesisPrivateValidator = genesisPrivateValidator
 		}
 	}
 
@@ -207,7 +207,7 @@ func generateAddressAndKey(keyAddressType string, blockPrivateValidator bool) (a
 			genesisPrivateValidator.Address = fmt.Sprintf("%X", address)
 		} else {
 			genesisPrivateValidator = nil
-		} 
+		}
 	}
 
 	return

--- a/chains/maker/files.go
+++ b/chains/maker/files.go
@@ -29,12 +29,12 @@ func SaveAccountResults(do *definitions.Do, accounts []*ErisDBAccountConstructor
 	// if asked to output the accounts with do.Output, and `eris chains make --unsafe` is not
 	// provided with the unsafe flag, then we no longer write the private keys in `accounts.json`
 	if !do.Unsafe {
-		log.Warn("The marmots care about your safety and no longer export the generated private keys onto your local host. "+
-			"If you do want accounts.json to contain the private keys for use in a development environment, please make your "+
-			"chain with `--unsafe` to write the private keys to disk.  This option will be deprecated once the javascript libraries "+
+		log.Warn("The marmots care about your safety and no longer export the generated private keys onto your local host. " +
+			"If you do want accounts.json to contain the private keys for use in a development environment, please make your " +
+			"chain with `--unsafe` to write the private keys to disk.  This option will be deprecated once the javascript libraries " +
 			"implements a remote signing path as tooling does.")
 	}
-	
+
 	addrFile, err := os.Create(filepath.Join(config.ChainsPath, do.Name, "addresses.csv"))
 	if err != nil {
 		return fmt.Errorf("Error creating addresses file. This usually means that there was a problem with the chain making process.")
@@ -85,7 +85,7 @@ func SaveAccountResults(do *definitions.Do, accounts []*ErisDBAccountConstructor
 				log.Error("Error writing addresses file.")
 				return err
 			}
-			_, err = actFile.WriteString(fmt.Sprintf("%s,%d,%s,%d,%d\n", publicKey, amount, 
+			_, err = actFile.WriteString(fmt.Sprintf("%s,%d,%s,%d,%d\n", publicKey, amount,
 				name, basePermissions.Perms, basePermissions.SetBit))
 			if err != nil {
 				log.Error("Error writing accounts file.")
@@ -98,7 +98,7 @@ func SaveAccountResults(do *definitions.Do, accounts []*ErisDBAccountConstructor
 					log.Error("Error writing validators file.")
 					return err
 				}
-			}			
+			}
 		}
 	}
 	addrFile.Sync()

--- a/chains/maker/maker.go
+++ b/chains/maker/maker.go
@@ -133,7 +133,7 @@ func maker(do *definitions.Do, consensusType string, accountTypes []*definitions
 
 	// use the accountConstructors to write the necessary files (config, genesis and private validator) per node
 	if err = MakeErisDBNodes(do.Name, do.SeedsIP, accounts, do.ChainImageName,
-			do.UseDataContainer, do.ExportedPorts, do.ContainerEntrypoint); err != nil {
+		do.UseDataContainer, do.ExportedPorts, do.ContainerEntrypoint); err != nil {
 		return err
 	}
 

--- a/docs/docs_generator.go
+++ b/docs/docs_generator.go
@@ -1,4 +1,4 @@
-package docs
+package main
 
 import (
 	"bufio"

--- a/perform/perform_test.go
+++ b/perform/perform_test.go
@@ -2,7 +2,6 @@ package perform
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"path"
 	"runtime"


### PR DESCRIPTION
addresses point 1 in #1230: make test for go tests

- introduce Makefile with the essentials and `make test` that runs `go test` on all non-vendor files
some ironing out:
- apply go fmt
- `/docs` does not build with conflicting package names
- add `/target` to gitignore as it contains local build output