### PR TITLE
Lookup service container IP address rather than relying on its hostname

### DIFF
--- a/services/services.go
+++ b/services/services.go
@@ -140,8 +140,14 @@ func ExecService(do *definitions.Do) (buf *bytes.Buffer, err error) {
 			log.Info("exec_host not found in service definition file")
 			log.WithField("service", do.Name).Info("May not be able to communicate with the service")
 		} else {
+			// Grab the Container to inspect the service's IP address
+			cont, err := util.DockerClient.InspectContainer(main)
+			if err != nil {
+				return nil, util.DockerError(err)
+			}
 			service.Service.Environment = append(service.Service.Environment,
-				fmt.Sprintf("%s=%s", service.Service.ExecHost, do.Name))
+				fmt.Sprintf("%s=%s", service.Service.ExecHost,
+					cont.NetworkSettings.IPAddress))
 		}
 
 		// Use service's short name as a link alias.


### PR DESCRIPTION
This should hopefully resolve an interaction with ISPs that DNS hijack and Alpine linux that does not seem to respect the lookup order between /etc/hosts and /etc/resolv.conf.

Regardless of that performing the lookup by inspecting docker is more robust than relying on chosen host name for the service to be resolvable. This mirrors how the chain container is found in 0.16.

Hopefully fixes #1228.

I've tested this locally by making a chain, starting it, and looking at the logs. Also `eris keys gen` works. Tools people please consider if this will have any unintended consequences because I'm not totally au fait with the eris codebase.